### PR TITLE
Add chart type option for LineChartMetric

### DIFF
--- a/resources/views/components/metrics/line.blade.php
+++ b/resources/views/components/metrics/line.blade.php
@@ -3,16 +3,18 @@
     'lines' => [],
     'colors' => [],
     'labels' => [],
+    'types' => [],
 ])
 <div
     {{ $attributes->merge(['class' => 'chart']) }}
     x-data="charts({
                 series: [
-                @foreach($lines as $line)
+                @foreach($lines as $lineKey => $line)
                     @foreach($line as $label => $values)
                     {
                         name: '{{ $label }}',
                         data: {{ json_encode(array_values($values)) }},
+                        type: '{{ $types[$lineKey][$label] }}',
                     },
                     @endforeach
                 @endforeach

--- a/resources/views/components/metrics/wrapped/line-chart.blade.php
+++ b/resources/views/components/metrics/wrapped/line-chart.blade.php
@@ -5,6 +5,7 @@
     'colors' => [],
     'columnSpanValue' => 12,
     'adaptiveColumnSpanValue' => 12,
+    'types' => [],
 ])
 <x-moonshine::layout.column
     :colSpan="$columnSpanValue"
@@ -17,6 +18,7 @@
             :colors="$colors"
             :labels="$labels"
             :title="$label"
+            :types="$types"
         />
     </x-moonshine::layout.box>
 </x-moonshine::layout.column>

--- a/src/Components/LineChartMetric.php
+++ b/src/Components/LineChartMetric.php
@@ -17,6 +17,8 @@ class LineChartMetric extends Metric
 
     protected array $colors = [];
 
+    protected array $types = [];
+
     protected bool $withoutSortKeys = false;
 
     protected function assets(): array
@@ -32,9 +34,11 @@ class LineChartMetric extends Metric
      */
     public function line(
         array|Closure $line,
-        string|array|Closure $color = '#7843E9'
+        string|array|Closure $color = '#7843E9',
+        string|array|Closure $type = 'area'
     ): static {
-        $this->lines[] = $line instanceof Closure ? $line() : $line;
+        $lines = $line instanceof Closure ? $line() : $line;
+        $this->lines[] = $lines;
 
         $color = $color instanceof Closure ? $color() : $color;
 
@@ -42,6 +46,14 @@ class LineChartMetric extends Metric
             $this->colors[] = $color;
         } else {
             $this->colors = $color;
+        }
+
+        $type = $type instanceof Closure ? $type() : $type;
+
+        if (is_string($type)) {
+            $this->types[] = array_fill_keys(array_keys($lines), $type);
+        } else {
+            $this->types[] = $type;
         }
 
         return $this;
@@ -72,6 +84,11 @@ class LineChartMetric extends Metric
         return $this->lines;
     }
 
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
     public function withoutSortKeys(): static
     {
         $this->withoutSortKeys = true;
@@ -93,6 +110,7 @@ class LineChartMetric extends Metric
             'labels' => $this->getLabels(),
             'lines' => $this->getLines(),
             'colors' => $this->getColors(),
+            'types' => $this->getTypes(),
         ];
     }
 }


### PR DESCRIPTION
This option allows you to specify the chart type, such as 'line,' 'column,' 'area,' and so on. By default, it remains 'line.'
You can combine multiple chart types on a single graph.






![Снимок экрана_2025-01-09_10-08-13](https://github.com/user-attachments/assets/22bbd5eb-f7e6-4e40-a877-5a1b6f9fa24e)
