### PR TITLE
Set events for LineChartMetric

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,3 +308,31 @@ LineChartMetric::make('Orders')
     ])
     ->height(600); 
 ```
+
+## ApexChart Events
+
+This method `setEvents()` allows you to use: [ApexCharts Events](https://apexcharts.com/docs/options/chart/events/).
+
+It works with both `DonutChartMetric` and `LineChartMetric`. For specific details and nuances, refer to the documentation: [ApexCharts Events Documentation](https://apexcharts.com/docs/options/chart/events/).
+
+```php
+use MoonShine\Apexcharts\Components\LineChartMetric;
+
+LineChartMetric::make('Orders')
+    ->line([
+        'Orders' => Order::query()
+            ->selectRaw('SUM(price) as sum, DATE_FORMAT(created_at, "%d.%m.%Y") as date')
+            ->groupBy('date')
+            ->pluck('sum','date')
+            ->toArray()
+    ], type: 'bar')
+    ->withoutSortKeys()
+    ->setEvents(<<<JS
+    {
+        dataPointSelection: function(event, chartContext, config) {
+            var pointIndex = config.dataPointIndex;
+            location.href = '/admin/page/dashboard/?point=' + (pointIndex + 1);
+        }
+    }
+    JS),
+```

--- a/resources/views/components/metrics/donut.blade.php
+++ b/resources/views/components/metrics/donut.blade.php
@@ -5,6 +5,7 @@
     'colors' => [],
     'decimals' => 3,
     'height' => 350,
+    'events' => '',
 ])
 
 <div
@@ -28,6 +29,7 @@
         chart: {
             height: {{ $height }},
             type: 'donut',
+            events: {!! $events !!}
         },
         stroke: {
             colors: ['transparent'],

--- a/resources/views/components/metrics/line.blade.php
+++ b/resources/views/components/metrics/line.blade.php
@@ -3,6 +3,7 @@
     'lines' => [],
     'colors' => [],
     'labels' => [],
+    'events' => '',
 ])
 <div
     {{ $attributes->merge(['class' => 'chart']) }}
@@ -22,6 +23,7 @@
                 chart: {
                     height: 300,
                     type: 'line',
+                    events: {!! $events !!}
                 },
                 yaxis: {
                     title: {

--- a/resources/views/components/metrics/wrapped/donut-chart.blade.php
+++ b/resources/views/components/metrics/wrapped/donut-chart.blade.php
@@ -7,6 +7,7 @@
     'columnSpanValue' => 12,
     'adaptiveColumnSpanValue' => 12,
     'height' => 350,
+    'events' => '',
 ])
 <x-moonshine::layout.column
     :colSpan="$columnSpanValue"
@@ -21,6 +22,7 @@
             :decimals="$decimals"
             :title="$label"
             :height="$height"
+            :events="$events"
         />
     </x-moonshine::layout.box>
 </x-moonshine::layout.column>

--- a/resources/views/components/metrics/wrapped/line-chart.blade.php
+++ b/resources/views/components/metrics/wrapped/line-chart.blade.php
@@ -5,6 +5,7 @@
     'colors' => [],
     'columnSpanValue' => 12,
     'adaptiveColumnSpanValue' => 12,
+    'events' => '',
 ])
 <x-moonshine::layout.column
     :colSpan="$columnSpanValue"
@@ -17,6 +18,7 @@
             :colors="$colors"
             :labels="$labels"
             :title="$label"
+            :events="$events"
         />
     </x-moonshine::layout.box>
 </x-moonshine::layout.column>

--- a/src/Components/DonutChartMetric.php
+++ b/src/Components/DonutChartMetric.php
@@ -20,6 +20,8 @@ class DonutChartMetric extends Metric
 
     protected int $height = 350;
 
+    protected string $events = '';
+
     protected function assets(): array
     {
         return [
@@ -93,6 +95,24 @@ class DonutChartMetric extends Metric
         return $this;
     }
 
+    public function setEvents(string $events): static
+    {
+        $this->events = $events;
+
+        return $this;
+    }
+
+    public function getEvents(): string
+    {
+        if($this->events === '') {
+            return <<<JS
+            {}
+            JS;
+        }
+
+        return $this->events;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -104,6 +124,7 @@ class DonutChartMetric extends Metric
             'colors' => $this->getColors(),
             'decimals' => $this->getDecimals(),
             'height' => $this->height,
+            'events' => $this->getEvents(),
         ];
     }
 }

--- a/src/Components/LineChartMetric.php
+++ b/src/Components/LineChartMetric.php
@@ -19,6 +19,8 @@ class LineChartMetric extends Metric
 
     protected bool $withoutSortKeys = false;
 
+    protected string $events = '';
+
     protected function assets(): array
     {
         return [
@@ -84,6 +86,24 @@ class LineChartMetric extends Metric
         return $this->withoutSortKeys;
     }
 
+    public function setEvents(string $events): static
+    {
+        $this->events = $events;
+
+        return $this;
+    }
+
+    public function getEvents(): string
+    {
+        if($this->events === '') {
+            return <<<JS
+            {}
+            JS;
+        }
+
+        return $this->events;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -93,6 +113,7 @@ class LineChartMetric extends Metric
             'labels' => $this->getLabels(),
             'lines' => $this->getLines(),
             'colors' => $this->getColors(),
+            'events' => $this->getEvents(),
         ];
     }
 }


### PR DESCRIPTION
Set events for LineChartMetric
Example:
`````
->setEvents(<<<JS
                {
                    dataPointSelection: function(event, chartContext, config) {
                        var pointIndex = config.dataPointIndex;
                        location.href = 'pages/month_info_all/?mon=' + (pointIndex + 1);
                    }
                }
                JS)
```