### PR TITLE
Added chart type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,14 @@ The `line()` method allows you to add a value line to the metric. You can add mu
 ```php
 line(
     array|Closure $line,
-    string|array|Closure $color = '#7843E9'
+    string|array|Closure $color = '#7843E9',
+    string|array|Closure $type = 'line',    
 )
 ```
 
 - `$line` - values for charting,
-- `$color` - line color.
+- `$color` - line color,
+- `$type` - chart type (line, area, column)
 
 ```php
 use MoonShine\Apexcharts\Components\LineChartMetric;
@@ -148,14 +150,14 @@ LineChartMetric::make('Orders')
             ->groupBy('date')
             ->pluck('sum','date')
             ->toArray()
-    ])
+    ], type: fn() => 'area')
     ->line([
         'Avg' => Order::query()
             ->selectRaw('AVG(price) as avg, DATE_FORMAT(created_at, "%d.%m.%Y") as date')
             ->groupBy('date')
             ->pluck('avg','date')
             ->toArray()
-    ], '#EC4176') 
+    ], '#EC4176', 'line'); 
 ```
 
 <picture>
@@ -181,7 +183,9 @@ LineChartMetric::make('Orders')
             ->toArray()
     ],[
         'red', 'blue'
-    ])
+    ], [
+        type: ['area', 'line']
+    ]);
 ```
 
 ### Sorting keys

--- a/resources/views/components/metrics/line.blade.php
+++ b/resources/views/components/metrics/line.blade.php
@@ -3,18 +3,18 @@
     'lines' => [],
     'colors' => [],
     'labels' => [],
-    'types' => [],
+    'types',
 ])
 <div
     {{ $attributes->merge(['class' => 'chart']) }}
     x-data="charts({
                 series: [
-                @foreach($lines as $lineKey => $line)
+                @foreach($lines as $line)
                     @foreach($line as $label => $values)
                     {
                         name: '{{ $label }}',
                         data: {{ json_encode(array_values($values)) }},
-                        type: '{{ $types[$lineKey][$label] }}',
+                        type: '{{ $types[$loop->parent->index % count($types)][$loop->index % count($types[$loop->parent->index])] }}',
                     },
                     @endforeach
                 @endforeach

--- a/resources/views/components/metrics/line.blade.php
+++ b/resources/views/components/metrics/line.blade.php
@@ -3,16 +3,18 @@
     'lines' => [],
     'colors' => [],
     'labels' => [],
+    'types' => [],
 ])
 <div
     {{ $attributes->merge(['class' => 'chart']) }}
     x-data="charts({
                 series: [
-                @foreach($lines as $line)
+                @foreach($lines as $lineKey => $line)
                     @foreach($line as $label => $values)
                     {
                         name: '{{ $label }}',
                         data: {{ json_encode(array_values($values)) }},
+                        type: '{{ $types[$lineKey][$label] }}',
                     },
                     @endforeach
                 @endforeach

--- a/resources/views/components/metrics/wrapped/line-chart.blade.php
+++ b/resources/views/components/metrics/wrapped/line-chart.blade.php
@@ -5,6 +5,7 @@
     'colors' => [],
     'columnSpanValue' => 12,
     'adaptiveColumnSpanValue' => 12,
+    'types' => [],
 ])
 <x-moonshine::layout.column
     :colSpan="$columnSpanValue"
@@ -17,6 +18,7 @@
             :colors="$colors"
             :labels="$labels"
             :title="$label"
+            :types="$types"
         />
     </x-moonshine::layout.box>
 </x-moonshine::layout.column>

--- a/src/Components/LineChartMetric.php
+++ b/src/Components/LineChartMetric.php
@@ -17,6 +17,8 @@ class LineChartMetric extends Metric
 
     protected array $colors = [];
 
+    protected array $types = [];
+
     protected bool $withoutSortKeys = false;
 
     protected function assets(): array
@@ -32,9 +34,11 @@ class LineChartMetric extends Metric
      */
     public function line(
         array|Closure $line,
-        string|array|Closure $color = '#7843E9'
+        string|array|Closure $color = '#7843E9',
+        string|array|Closure $type = 'area'
     ): static {
-        $this->lines[] = $line instanceof Closure ? $line() : $line;
+        $lines = $line instanceof Closure ? $line() : $line;
+        $this->lines[] = $lines;
 
         $color = $color instanceof Closure ? $color() : $color;
 
@@ -42,6 +46,14 @@ class LineChartMetric extends Metric
             $this->colors[] = $color;
         } else {
             $this->colors = $color;
+        }
+
+        $type = $type instanceof Closure ? $type() : $type;
+
+        if (is_string($type)) {
+            $this->types[] = array_fill_keys(array_keys($lines), $type);
+        } else {
+            $this->types[] = $type;
         }
 
         return $this;
@@ -72,6 +84,11 @@ class LineChartMetric extends Metric
         return $this->lines;
     }
 
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
     public function withoutSortKeys(): static
     {
         $this->withoutSortKeys = true;
@@ -93,6 +110,7 @@ class LineChartMetric extends Metric
             'labels' => $this->getLabels(),
             'lines' => $this->getLines(),
             'colors' => $this->getColors(),
+            'types' => $this->getTypes(),
         ];
     }
 }

--- a/src/Components/LineChartMetric.php
+++ b/src/Components/LineChartMetric.php
@@ -35,7 +35,7 @@ class LineChartMetric extends Metric
     public function line(
         array|Closure $line,
         string|array|Closure $color = '#7843E9',
-        string|array|Closure $type = 'area'
+        string|array|Closure $type = 'line'
     ): static {
         $lines = $line instanceof Closure ? $line() : $line;
         $this->lines[] = $lines;
@@ -51,17 +51,12 @@ class LineChartMetric extends Metric
         $type = $type instanceof Closure ? $type() : $type;
 
         if (is_string($type)) {
-            $this->types[] = array_fill_keys(array_keys($lines), $type);
+            $this->types[][] = $type;
         } else {
             $this->types[] = $type;
         }
 
         return $this;
-    }
-
-    public function getColor(int $index): string
-    {
-        return $this->colors[$index];
     }
 
     public function getColors(): array


### PR DESCRIPTION
The size of the array of types may not match the strings.

For testing:
```php
Grid::make([
    Column::make([
        LineChartMetric::make('Заказы')
            ->line([
                'Выручка 1' => [
                    now()->format('Y-m-d') => 100,
                    now()->addDay()->format('Y-m-d') => 200
                ]
            ], type: fn() => ['line', 'line'])
            ->line([
                'Выручка 2' => [
                    now()->format('Y-m-d') => 300,
                    now()->addDay()->format('Y-m-d') => 400
                ]
            ], '#EC4176',  type: fn() => 'area'),
    ])->columnSpan(6),

    Column::make([
        LineChartMetric::make('Заказы')
            ->line(
                [
                    'Выручка 1' => [
                        now()->format('Y-m-d') => 100,
                        now()->addDay()->format('Y-m-d') => 200
                    ],
                    'Выручка 2' => [
                        now()->format('Y-m-d') => 200,
                        now()->addDay()->format('Y-m-d') => 300
                    ],
                    'Выручка 3' => [
                        now()->format('Y-m-d') => 300,
                        now()->addDay()->format('Y-m-d') => 400
                    ],
                ],
                color: ['#EC4176' , '#7843E9'],
                type: ['area', 'line', 'line']
            ),
    ])->columnSpan(6),
]),
```

